### PR TITLE
feat: 행사 상세페이지에 환경임팩트 지수 추가(#65)

### DIFF
--- a/src/components/pages/events/EventDetail/EventDetail.module.css
+++ b/src/components/pages/events/EventDetail/EventDetail.module.css
@@ -241,6 +241,103 @@
   margin-bottom: 32px;
 }
 
+.event-impact-section {
+  background-color: white;
+  border-radius: 16px;
+  padding: 32px;
+  margin-bottom: 32px;
+}
+
+.impact-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+}
+
+.impact-item {
+  text-align: center;
+}
+
+.impact-icon {
+  border-radius: 16px;
+  height: 72px;
+  width: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 20px;
+}
+
+.impact-icon.co2-icon {
+  background-color: #10b981;
+}
+
+.impact-icon.water-icon {
+  background-color: #2563eb;
+}
+
+.impact-icon.energy-icon {
+  background-color: #d97706;
+}
+
+.impact-icon img {
+  width: 28px;
+  height: 28px;
+  object-fit: contain;
+  aspect-ratio: 1 / 1;
+  filter: brightness(0) invert(1);
+  opacity: 1;
+}
+
+.impact-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.impact-number {
+  font-family: "Pretendard", sans-serif;
+  font-size: 36px;
+  font-weight: 400;
+  color: #1f2937;
+  margin: 0 0 12px 0;
+  line-height: 44px;
+}
+
+.impact-label {
+  font-family: "Pretendard", sans-serif;
+  font-size: 14px;
+  color: #6b7280;
+  margin: 0;
+  line-height: 20px;
+}
+
+.impact-message {
+  background-color: #f9fafb;
+  border-radius: 12px;
+  padding: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  text-align: center;
+}
+
+.impact-message img {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  filter: none;
+}
+
+.impact-message p {
+  font-family: "Pretendard", sans-serif;
+  font-size: 16px;
+  color: #6b7280;
+  margin: 0;
+  line-height: 24px;
+}
+
 .event-info-main-section {
   background-color: white;
   border-radius: 16px;
@@ -759,6 +856,10 @@
     grid-template-columns: repeat(2, 1fr);
   }
 
+  .impact-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
   .event-details-grid {
     flex-direction: column;
     gap: 24px;
@@ -778,6 +879,7 @@
   .event-usage-section,
   .event-precaution-section,
   .event-results-section,
+  .event-impact-section,
   .event-info-main-section,
   .staff-code-section,
   .event-info-section {
@@ -785,6 +887,11 @@
   }
 
   .results-grid {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+
+  .impact-grid {
     grid-template-columns: 1fr;
     gap: 16px;
   }

--- a/src/components/pages/events/EventDetail/EventDetail.tsx
+++ b/src/components/pages/events/EventDetail/EventDetail.tsx
@@ -10,6 +10,9 @@ const imgFrame2 = "/admin/img/icon/location-pin.svg";
 const imgFrame3 = "/admin/img/icon/user-count.svg";
 const imgFrame9 = "/admin/img/icon/alert.svg";
 const editIcon = "/admin/img/icon/edit.svg";
+const co2Icon = "/admin/img/icon/co2.svg";
+const waterIcon = "/admin/img/icon/water.svg";
+const energyIcon = "/admin/img/icon/energy.svg";
 
 interface EventImage {
   imageId: number;
@@ -38,6 +41,14 @@ interface EventApplication {
   reason: string | null;
 }
 
+interface ImpactAnalytics {
+  available: boolean;
+  co2Saved: number | null;
+  waterSaved: number | null;
+  energySaved: number | null;
+  message: string | null;
+}
+
 interface EventDetailResponse {
   eventId: number;
   title: string;
@@ -63,6 +74,7 @@ interface EventDetailResponse {
   images: EventImage[];
   options: EventOption[];
   applications: EventApplication[];
+  impactAnalytics: ImpactAnalytics;
 }
 
 const EventDetail: React.FC = () => {
@@ -465,6 +477,59 @@ const EventDetail: React.FC = () => {
                 </div>
               </div>
             </div>
+          </div>
+
+          {/* 환경 임팩트 섹션 */}
+          <div className={styles["event-impact-section"]}>
+            <h3 className={styles["section-title"]}>환경 임팩트</h3>
+            {eventData.impactAnalytics?.available ? (
+              <div className={styles["impact-grid"]}>
+                <div className={styles["impact-item"]}>
+                  <div className={`${styles["impact-icon"]} ${styles["co2-icon"]}`}>
+                    <img src={co2Icon} alt="CO2 아이콘" />
+                  </div>
+                  <div className={styles["impact-content"]}>
+                    <p className={styles["impact-number"]}>
+                      {eventData.impactAnalytics.co2Saved !== null && eventData.impactAnalytics.co2Saved !== undefined
+                        ? Math.round(eventData.impactAnalytics.co2Saved).toLocaleString()
+                        : 0}
+                    </p>
+                    <p className={styles["impact-label"]}>CO2 절감량 (kg)</p>
+                  </div>
+                </div>
+                <div className={styles["impact-item"]}>
+                  <div className={`${styles["impact-icon"]} ${styles["water-icon"]}`}>
+                    <img src={waterIcon} alt="물 아이콘" />
+                  </div>
+                  <div className={styles["impact-content"]}>
+                    <p className={styles["impact-number"]}>
+                      {eventData.impactAnalytics.waterSaved !== null && eventData.impactAnalytics.waterSaved !== undefined
+                        ? Math.round(eventData.impactAnalytics.waterSaved).toLocaleString()
+                        : 0}
+                    </p>
+                    <p className={styles["impact-label"]}>물 절약량 (L)</p>
+                  </div>
+                </div>
+                <div className={styles["impact-item"]}>
+                  <div className={`${styles["impact-icon"]} ${styles["energy-icon"]}`}>
+                    <img src={energyIcon} alt="에너지 아이콘" />
+                  </div>
+                  <div className={styles["impact-content"]}>
+                    <p className={styles["impact-number"]}>
+                      {eventData.impactAnalytics.energySaved !== null && eventData.impactAnalytics.energySaved !== undefined
+                        ? Math.round(eventData.impactAnalytics.energySaved).toLocaleString()
+                        : 0}
+                    </p>
+                    <p className={styles["impact-label"]}>에너지 절약량 (kWh)</p>
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <div className={styles["impact-message"]}>
+                <img src={imgFrame9} alt="알림 아이콘" />
+                <p>{eventData.impactAnalytics?.message || "행사 종료 후 집계 예정입니다."}</p>
+              </div>
+            )}
           </div>
 
           {/* 행사 정보 섹션 */}


### PR DESCRIPTION
# Pull Request

### 📝 작업내용

행사 상세 페이지에 환경 임팩트 수치 표시 기능을 추가했습니다.

**주요 변경사항:**
- `EventDetail` 컴포넌트에 환경 임팩트 섹션 추가
- API 응답의 `impactAnalytics` 필드를 활용하여 환경 보호 효과 표시
- `available` 상태에 따라 수치 또는 안내 메시지 표시
- 반응형 디자인 적용

**변경된 파일:**
- `src/components/pages/events/EventDetail/EventDetail.tsx`
- `src/components/pages/events/EventDetail/EventDetail.module.css`

### 🔧 구현 내용

1. **인터페이스 추가**
   - `ImpactAnalytics` 인터페이스 정의
   - `EventDetailResponse`에 `impactAnalytics` 필드 추가

2. **UI 구현**
   - 환경 임팩트 섹션 추가 (행사 통계 섹션 다음 위치)
   - `available === true`일 때: CO2 절감량, 물 절약량, 에너지 절약량 표시
   - `available === false`일 때: 안내 메시지 표시

3. **스타일링**
   - 행사 통계 섹션과 일관된 디자인 적용
   - 각 항목별 색상: CO2(녹색 #10b981), 물(파란색 #2563eb), 에너지(주황색 #d97706)
   - 반응형 그리드 레이아웃 (모바일: 1열, 태블릿: 2열, 데스크톱: 3열)

### ✅ 체크리스트

- [x] 코드 리뷰 준비 완료
- [x] 린터 오류 없음
- [x] 타입스크립트 타입 정의 완료
- [x] 반응형 디자인 적용
- [x] API 응답 구조에 맞게 구현
- [x] null/undefined 값 처리
